### PR TITLE
Build clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,15 @@ ADD http://llvm.org/releases/3.8.1/llvm-3.8.1.src.tar.xz .
 RUN xzcat llvm-3.8.1.src.tar.xz | tar xf -
 ADD http://llvm.org/releases/3.8.1/cfe-3.8.1.src.tar.xz .
 RUN xzcat cfe-3.8.1.src.tar.xz | tar xf - && mv cfe-3.8.1.src llvm-3.8.1.src/tools/clang
-RUN source /hbb_shlib/activate && \
+RUN source /opt/rh/devtoolset-2/enable && \
     mkdir llvm-build && cd llvm-build && \
-    cmake ../llvm-3.8.1.src/ \
+    CC=gcc CXX=g++ /hbb/bin/cmake ../llvm-3.8.1.src/ \
         -DCMAKE_INSTALL_PREFIX=/opt/clang \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_TARGETS_TO_BUILD=host \
         -DGCC_INSTALL_PREFIX=/opt/rh/devtoolset-2/root/usr/ \
         && \
-    make -j 8 && \
+    make && \
     make install
 
 # Disable PYTHONPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,18 +31,6 @@ RUN source /opt/rh/devtoolset-2/enable && \
     make install/strip
 RUN rm -rf /llvm-3.8.1.src /llvm-3.8.1.src.tar.xz /cfe-3.8.1.src.tar.xz /llvm-build
 
-# Disable PYTHONPATH
-ENV PYTHONPATH=""
-
-# Install miniconda
-RUN set -x && \
-    curl -s -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
-ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
-RUN conda config --add channels omnia && \
-    conda install -yq conda-build jinja2 anaconda-client
-RUN rm -rf Miniconda3-latest-Linux-x86_64.sh
-
 # Install AMD APP SDK
 #ADD https://jenkins.choderalab.org/userContent/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 .
 ADD http://s3.amazonaws.com/omnia-ci/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN source /opt/rh/devtoolset-2/enable && \
         -DGCC_INSTALL_PREFIX=/opt/rh/devtoolset-2/root/usr/ \
         && \
     make && \
-    make install
+    make install/strip
+RUN rm -rf /llvm-3.8.1.src /llvm-3.8.1.src.tar.xz /cfe-3.8.1.src.tar.xz /llvm-build
 
 # Disable PYTHONPATH
 ENV PYTHONPATH=""
@@ -40,6 +41,7 @@ RUN set -x && \
 ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:/opt/rh/autotools-latest/root/usr/bin:/anaconda/bin:$PATH
 RUN conda config --add channels omnia && \
     conda install -yq conda-build jinja2 anaconda-client
+RUN rm -rf Miniconda3-latest-Linux-x86_64.sh
 
 # Install AMD APP SDK
 #ADD https://jenkins.choderalab.org/userContent/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 .


### PR DESCRIPTION
This seems to be working. Key is to use hbb_shlib instead of hbb_exe. I also switched to using cmake for building. It was printing an angry deprecation notice that autotools will be removed in clang 3.9. I also have it looking in the right place for the gcc 4.8's libstdc++. [As far as I understand it, llvm/clang _does not_ ship its own c++ runtime library. It would be interesting to run benchmarks with the same version of clang but different versions of gcc]

It takes forever to compile so things are still compiling locally. Won't know for sure if it worked.
